### PR TITLE
Python3

### DIFF
--- a/tablestore/__init__.py
+++ b/tablestore/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf8 -*
+#  @Author  : LiXiaoran
 
 __version__ = '4.1.0'
 __all__ = [

--- a/tablestore/client.py
+++ b/tablestore/client.py
@@ -4,7 +4,7 @@
 __all__ = ['OTSClient']
 
 import sys
-import urlparse
+import urllib.parse
 import time
 import _strptime
 
@@ -93,7 +93,7 @@ class OTSClient(object):
             self.logger = logging.getLogger(logger_name)
 
         # parse end point
-        scheme, netloc, path = urlparse.urlparse(end_point)[:3]
+        scheme, netloc, path = urllib.parse.urlparse(end_point)[:3]
         host = scheme + "://" + netloc
 
         if scheme != 'http' and scheme != 'https':

--- a/tablestore/client.py
+++ b/tablestore/client.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 # Implementation of OTSClient
 
 __all__ = ['OTSClient']

--- a/tablestore/connection.py
+++ b/tablestore/connection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf8 -*-
 
-import httplib
+import http.client
 import time
 
 from urllib3.poolmanager import PoolManager

--- a/tablestore/connection.py
+++ b/tablestore/connection.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import http.client
 import time

--- a/tablestore/const.py
+++ b/tablestore/const.py
@@ -7,7 +7,7 @@ class Const(object):
         pass
 
     def __setattr__(self, name, value):
-        if self.__dict__.has_key(name):
+        if name in self.__dict__:
             raise self.ConstError("can't change const.%s" % name)
         if not name.isupper():
             raise self.ConstCaseError("const name '%s' is not all uppercase" % name)

--- a/tablestore/const.py
+++ b/tablestore/const.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 class Const(object):
     class ConstError(TypeError): 

--- a/tablestore/error.py
+++ b/tablestore/error.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 class OTSError(Exception):
     pass

--- a/tablestore/metadata.py
+++ b/tablestore/metadata.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 from tablestore.error import *
 

--- a/tablestore/metadata.py
+++ b/tablestore/metadata.py
@@ -438,7 +438,7 @@ class BatchGetRowResponse(object):
     def get_result(self):
         succ = []
         fail = []
-        for rows in self.items.values():
+        for rows in list(self.items.values()):
             for row in rows:
                 if row.is_ok:
                     succ.append(row)
@@ -492,7 +492,7 @@ class BatchWriteRowResponse(object):
         self.table_of_update = {}
         self.table_of_delete = {}
         
-        for table_name in response.keys():
+        for table_name in list(response.keys()):
             put_list = []
             update_list = []
             delete_list = []
@@ -513,7 +513,7 @@ class BatchWriteRowResponse(object):
         succ = []
         fail = []
 
-        for rows in self.table_of_put.values():
+        for rows in list(self.table_of_put.values()):
             for row in rows:
                 if row.is_ok:
                     succ.append(row)
@@ -539,7 +539,7 @@ class BatchWriteRowResponse(object):
         succ = []
         fail = []
 
-        for rows in self.table_of_update.values():
+        for rows in list(self.table_of_update.values()):
             for row in rows:
                 if row.is_ok:
                     succ.append(row)
@@ -565,7 +565,7 @@ class BatchWriteRowResponse(object):
         succ = []
         fail = []
 
-        for rows in self.table_of_delete.values():
+        for rows in list(self.table_of_delete.values()):
             for row in rows:
                 if row.is_ok:
                     succ.append(row)

--- a/tablestore/plainbuffer/plain_buffer_builder.py
+++ b/tablestore/plainbuffer/plain_buffer_builder.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+# @Author  : LiXiaoran
 
 import sys
 import tablestore 

--- a/tablestore/plainbuffer/plain_buffer_builder.py
+++ b/tablestore/plainbuffer/plain_buffer_builder.py
@@ -3,10 +3,10 @@
 import sys
 import tablestore 
 from tablestore.metadata import *
-from plain_buffer_consts import *
-from plain_buffer_crc8 import *
-from plain_buffer_stream import *
-from plain_buffer_coded_stream import *
+from .plain_buffer_consts import *
+from .plain_buffer_crc8 import *
+from .plain_buffer_stream import *
+from .plain_buffer_coded_stream import *
 
 class PlainBufferBuilder(object):
     @staticmethod
@@ -18,9 +18,9 @@ class PlainBufferBuilder(object):
             size += 1
             return size
 
-        if isinstance(value, int) or isinstance(value, long):
+        if isinstance(value, int) or isinstance(value, int):
             size += 8  #sizeof(int64_t)
-        elif isinstance(value, str) or isinstance(value, unicode):
+        elif isinstance(value, str) or isinstance(value, str):
             size += const.LITTLE_ENDIAN_32_SIZE
             size += len(value)
         elif isinstance(value, bytearray):
@@ -50,9 +50,9 @@ class PlainBufferBuilder(object):
 
         if isinstance(value, bool):
             size += 1
-        elif isinstance(value, int) or isinstance(value, long): 
+        elif isinstance(value, int) or isinstance(value, int): 
             size += LITTLE_ENDIAN_64_SIZE
-        elif isinstance(value, str) or isinstance(value, unicode):
+        elif isinstance(value, str) or isinstance(value, str):
             size += const.LITTLE_ENDIAN_32_SIZE
             size += len(value)
         elif isinstance(value, bytearray):
@@ -120,9 +120,9 @@ class PlainBufferBuilder(object):
 
         if len(attribute_columns) != 0:
             size += 1
-            for update_type in attribute_columns.keys():
+            for update_type in list(attribute_columns.keys()):
                 columns = attribute_columns[update_type]
-                if isinstance(columns, str) or isinstance(columns, unicode):
+                if isinstance(columns, str) or isinstance(columns, str):
                     size += PlainBufferBuilder.compute_column_size2(column, None, update_type)
                 elif isinstance(columns, list):
                     for column in columns:
@@ -197,7 +197,7 @@ class PlainBufferBuilder(object):
         if not isinstance(attribute_columns, dict):
             raise OTSClientError("the attribute columns of UpdateRow is not dict, but is %s" % str(type(attribute_columns)))
 
-        for key in attribute_columns.keys():
+        for key in list(attribute_columns.keys()):
             if not isinstance(attribute_columns[key], list):
                 raise OTSClientError("the columns value of update-row must be list, but is %s" % 
                                      str(type(attribute_columns.values)))

--- a/tablestore/plainbuffer/plain_buffer_builder.py
+++ b/tablestore/plainbuffer/plain_buffer_builder.py
@@ -8,11 +8,12 @@ from .plain_buffer_crc8 import *
 from .plain_buffer_stream import *
 from .plain_buffer_coded_stream import *
 
+
 class PlainBufferBuilder(object):
     @staticmethod
     def compute_primary_key_value_size(value):
         size = 1   # TAG_CELL_VALUE
-        size += const.LITTLE_ENDIAN_32_SIZE + 1  # length + type
+        size += const.LITTLE_ENDIAN_SIZE + 1  # length + type
 
         if value in [INF_MIN, INF_MAX, PK_AUTO_INCR]:
             size += 1
@@ -21,10 +22,10 @@ class PlainBufferBuilder(object):
         if isinstance(value, int) or isinstance(value, int):
             size += 8  #sizeof(int64_t)
         elif isinstance(value, str) or isinstance(value, str):
-            size += const.LITTLE_ENDIAN_32_SIZE
+            size += const.LITTLE_ENDIAN_SIZE
             size += len(value)
         elif isinstance(value, bytearray):
-            size += const.LITTLE_ENDIAN_32_SIZE
+            size += const.LITTLE_ENDIAN_SIZE
             size += len(value)
         else:
             raise OTSClientError("Unsupported primary key type:" + str(type(value)))
@@ -32,12 +33,12 @@ class PlainBufferBuilder(object):
        
     @staticmethod
     def compute_variant_value_size(value):
-        return PlainBufferBuilder.compute_primary_key_value_size(value) - const.LITTLE_ENDIAN_32_SIZE - 1
+        return PlainBufferBuilder.compute_primary_key_value_size(value) - const.LITTLE_ENDIAN_SIZE - 1
 
     @staticmethod
     def compute_primary_key_column_size(pk_name, pk_value):
         size = 1
-        size += 1 + const.LITTLE_ENDIAN_32_SIZE
+        size += 1 + const.LITTLE_ENDIAN_SIZE
         size += len(pk_name)
         size += PlainBufferBuilder.compute_primary_key_value_size(pk_value)
         size += 2
@@ -46,17 +47,17 @@ class PlainBufferBuilder(object):
     @staticmethod
     def compute_column_value_size(value):
         size = 1
-        size += const.LITTLE_ENDIAN_32_SIZE + 1
+        size += const.LITTLE_ENDIAN_SIZE + 1
 
         if isinstance(value, bool):
             size += 1
         elif isinstance(value, int) or isinstance(value, int): 
             size += LITTLE_ENDIAN_64_SIZE
         elif isinstance(value, str) or isinstance(value, str):
-            size += const.LITTLE_ENDIAN_32_SIZE
+            size += const.LITTLE_ENDIAN_SIZE
             size += len(value)
         elif isinstance(value, bytearray):
-            size += const.LITTLE_ENDIAN_32_SIZE
+            size += const.LITTLE_ENDIAN_SIZE
             size += len(value)
         elif isinstance(value, float):
             size += LITTLE_ENDIAN_64_SIZE
@@ -66,12 +67,12 @@ class PlainBufferBuilder(object):
 
     @staticmethod
     def compute_variant_value_size(column_value):
-        return PlainBufferBuilder.compute_column_value_size(column_value) - const.LITTLE_ENDIAN_32_SIZE - 1
+        return PlainBufferBuilder.compute_column_value_size(column_value) - const.LITTLE_ENDIAN_SIZE - 1
     
     @staticmethod
     def compute_column_size(column_name, column_value, timestamp = None):
         size = 1
-        size += 1 + const.LITTLE_ENDIAN_32_SIZE
+        size += 1 + const.LITTLE_ENDIAN_SIZE
         size += len(column_name)
         if column_value is not None:
             size += PlainBufferBuilder.compute_column_value_size(column_value) 
@@ -99,7 +100,7 @@ class PlainBufferBuilder(object):
     
     @staticmethod
     def compute_put_row_size(primary_key, attribute_columns):
-        size = const.LITTLE_ENDIAN_32_SIZE
+        size = const.LITTLE_ENDIAN_SIZE
         size += PlainBufferBuilder.compute_primary_key_size(primary_key)
 
         if len(attribute_columns) != 0:
@@ -115,7 +116,7 @@ class PlainBufferBuilder(object):
 
     @staticmethod
     def compute_update_row_size(primary_key, attribute_columns):
-        size = const.LITTLE_ENDIAN_32_SIZE
+        size = const.LITTLE_ENDIAN_SIZE
         size += PlainBufferBuilder.compute_primary_key_size(primary_key)
 
         if len(attribute_columns) != 0:
@@ -138,7 +139,7 @@ class PlainBufferBuilder(object):
     
     @staticmethod
     def compute_delete_row_size(primary_key):
-        size = const.LITTLE_ENDIAN_32_SIZE
+        size = const.LITTLE_ENDIAN_SIZE
         size += PlainBufferBuilder.compute_primary_key_size(primary_key)
         size += 3
         return size
@@ -163,7 +164,7 @@ class PlainBufferBuilder(object):
 
     @staticmethod
     def serialize_primary_key(primary_key):
-        buf_size = const.LITTLE_ENDIAN_32_SIZE
+        buf_size = const.LITTLE_ENDIAN_SIZE
         buf_size += PlainBufferBuilder.compute_primary_key_size(primary_key)
         buf_size += 2
 

--- a/tablestore/plainbuffer/plain_buffer_coded_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_coded_stream.py
@@ -322,7 +322,9 @@ class PlainBufferCodedOutputStream(object):
             cell_check_sum = PlainBufferCrc8.crc_int32(cell_check_sum, len(value))
             cell_check_sum = PlainBufferCrc8.crc_string(cell_check_sum, value.decode("utf-8"))
         elif isinstance(value, float):
-            double_in_long, = struct.unpack("l", struct.pack("d", value))
+            #in 64bit system  long shoud be 8 bytes,use the type of long long
+            double_in_long, = struct.unpack("q", struct.pack("d", value))
+            # double_in_long, = struct.unpack("l", struct.pack("d", value))
             self.output_stream.write_raw_little_endian32(1 + LITTLE_ENDIAN_64_SIZE)
             self.output_stream.write_raw_byte(VT_DOUBLE)
             self.output_stream.write_double(value)
@@ -371,6 +373,7 @@ class PlainBufferCodedOutputStream(object):
 
         if timestamp is not None:
             self.write_tag(TAG_CELL_TIMESTAMP)
+            #timestamp in 64bit system should be different from 32bit system
             self.output_stream.write_raw_little_endian64(timestamp)
             cell_check_sum = PlainBufferCrc8.crc_int64(cell_check_sum, timestamp)
         self.write_tag(TAG_CELL_CHECKSUM)

--- a/tablestore/plainbuffer/plain_buffer_coded_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_coded_stream.py
@@ -95,7 +95,12 @@ class PlainBufferCodedInputStream(object):
             cell_check_sum = PlainBufferCrc8.crc_int64(cell_check_sum, double_int)
             self.read_tag()
             #long in 64bit system should be 8 bit long
-            double_value, = struct.unpack('d', struct.pack('q', double_int))
+            if const.SYS_BITS == 64:
+                double_value, = struct.unpack('d', struct.pack('q', double_int))
+            elif const.SYS_BITS == 32:
+                double_value, = struct.unpack('d', struct.pack('l', double_int))
+            else:
+                double_value, = struct.unpack('d', struct.pack('l', double_int))
             return (double_value, cell_check_sum)
         else:
             raise OTSClientError("Unsupported column type: " + str(column_type))
@@ -332,8 +337,12 @@ class PlainBufferCodedOutputStream(object):
             cell_check_sum = PlainBufferCrc8.crc_string(cell_check_sum, value.decode("utf-8"))
         elif isinstance(value, float):
             #in 64bit system  long shoud be 8 bytes,use the type of long long
-            double_in_long, = struct.unpack("q", struct.pack("d", value))
-            # double_in_long, = struct.unpack("l", struct.pack("d", value))
+            if const.SYS_BITS == 64:
+                double_in_long, = struct.unpack("q", struct.pack("d", value))
+            elif const.SYS_BITS == 32:
+                double_in_long, = struct.unpack("l", struct.pack("d", value))
+            else:
+                double_in_long, = struct.unpack("l", struct.pack("d", value))
             self.output_stream.write_raw_little_endian32(1 + LITTLE_ENDIAN_64_SIZE)
             self.output_stream.write_raw_byte(VT_DOUBLE)
             self.output_stream.write_double(value)

--- a/tablestore/plainbuffer/plain_buffer_coded_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_coded_stream.py
@@ -31,7 +31,7 @@ class PlainBufferCodedInputStream(object):
             raise OTSClientError("Expect TAG_CELL_VALUE but it was " + str(self.get_last_tag()))
 
         self.input_stream.read_raw_little_endian32()
-        column_type = ord(self.input_stream.read_raw_byte().decode())
+        column_type = ord(self.input_stream.read_raw_byte().decode('utf-8'))
         if column_type == VT_INTEGER:
             int64_value = self.input_stream.read_int64()
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_INTEGER)
@@ -61,7 +61,7 @@ class PlainBufferCodedInputStream(object):
         if not self.check_last_tag_was(TAG_CELL_VALUE):
             raise OTSClientError("Expect TAG_CELL_VALUE but it was " + str(self.get_last_tag()))
         self.input_stream.read_raw_little_endian32()
-        column_type = ord(self.input_stream.read_raw_byte().decode())
+        column_type = ord(self.input_stream.read_raw_byte().decode('utf-8'))
         if column_type == VT_INTEGER:
             int64_value = self.input_stream.read_int64()
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_INTEGER)
@@ -126,7 +126,7 @@ class PlainBufferCodedInputStream(object):
         primary_key_value, cell_check_sum = self.read_primary_key_value(cell_check_sum)
         
         if self.get_last_tag() == TAG_CELL_CHECKSUM:
-            check_sum = ord(self.input_stream.read_raw_byte().decode())
+            check_sum = ord(self.input_stream.read_raw_byte().decode('utf-8'))
             if check_sum != cell_check_sum:
                 raise OTSClientError("Checksum mismatch. expected:" + str(check_sum) + ",actual:" + str(cell_check_sum))
             self.read_tag()
@@ -166,7 +166,7 @@ class PlainBufferCodedInputStream(object):
             self.read_tag()
 
         if self.get_last_tag() == TAG_CELL_CHECKSUM:
-            check_sum = ord(self.input_stream.read_raw_byte().decode())
+            check_sum = ord(self.input_stream.read_raw_byte().decode('utf-8'))
             if check_sum != cell_check_sum:                
                 raise OTSClientError("Checksum mismatch. expected:" + str(check_sum) + ",actual:" + str(cell_check_sum))
             self.read_tag()
@@ -189,9 +189,9 @@ class PlainBufferCodedInputStream(object):
         while self.check_last_tag_was(TAG_CELL):
             (name, value, row_check_sum) = self.read_primary_key_column(row_check_sum)
             if isinstance(name,bytes):
-                name = name.decode()
+                name = name.decode('utf-8')
             if isinstance(value,bytes):
-                value = value.decode()
+                value = value.decode('utf-8')
             primary_key.append((name, value))
 
         if self.check_last_tag_was(TAG_ROW_DATA):
@@ -199,9 +199,9 @@ class PlainBufferCodedInputStream(object):
             while self.check_last_tag_was(TAG_CELL):
                 column_name, column_value, timestamp, row_check_sum = self.read_column(row_check_sum)
                 if isinstance(column_name, bytes):
-                    column_name = column_name.decode()
+                    column_name = column_name.decode('utf-8')
                 if isinstance(column_value, bytes):
-                    column_value = column_value.decode()
+                    column_value = column_value.decode('utf-8')
                 attributes.append((column_name, column_value, timestamp))
 
         if self.check_last_tag_was(TAG_DELETE_ROW_MARKER):
@@ -211,7 +211,7 @@ class PlainBufferCodedInputStream(object):
             row_check_sum = PlainBufferCrc8.crc_int8(row_check_sum, 0)
 
         if self.check_last_tag_was(TAG_ROW_CHECKSUM):
-            check_sum = ord(self.input_stream.read_raw_byte().decode())
+            check_sum = ord(self.input_stream.read_raw_byte().decode('utf-8'))
             if check_sum != row_check_sum:
                 raise OTSClientError("Checksum is mismatch.")
             self.read_tag()

--- a/tablestore/plainbuffer/plain_buffer_coded_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_coded_stream.py
@@ -283,7 +283,7 @@ class PlainBufferCodedOutputStream(object):
             self.output_stream.write_raw_little_endian32(len(string_value))
             self.output_stream.write_bytes(string_value)
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_STRING)
-            cell_check_sum = PlainBufferCrc8.crc_int32(cell_check_sum, len(string_value))
+            cell_check_sum = PlainBufferCrc8.crc_int32(cell_check_sum, len(string_value.encode('utf-8')))
             cell_check_sum = PlainBufferCrc8.crc_string(cell_check_sum, string_value)
         elif isinstance(value, bytearray):
             binary_value = value
@@ -325,7 +325,8 @@ class PlainBufferCodedOutputStream(object):
             self.output_stream.write_raw_little_endian32(len(value))
             self.output_stream.write_bytes(value)
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_STRING)
-            cell_check_sum = PlainBufferCrc8.crc_int32(cell_check_sum, len(value))
+            #需要求的是bytes的长度
+            cell_check_sum = PlainBufferCrc8.crc_int32(cell_check_sum, len(value.encode('utf-8')))
             cell_check_sum = PlainBufferCrc8.crc_string(cell_check_sum, value)
         elif isinstance(value, bytearray):
             prefix_length = LITTLE_ENDIAN_32_SIZE + 1
@@ -362,7 +363,7 @@ class PlainBufferCodedOutputStream(object):
             self.output_stream.write_raw_little_endian64(value)
         elif isinstance(value, str) or isinstance(value, str):
             self.output_stream.write_raw_byte(VT_STRING)
-            self.output_stream.write_raw_little_endian32(len(value))
+            self.output_stream.write_raw_little_endian32(len(value.encode('utf-8')))
             self.output_stream.write_bytes(value)
         elif isinstance(value, bytearray):
             self.output_stream.write_raw_byte(VT_BLOB)

--- a/tablestore/plainbuffer/plain_buffer_coded_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_coded_stream.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import sys
 import struct
@@ -391,7 +392,7 @@ class PlainBufferCodedOutputStream(object):
 
         if timestamp is not None:
             self.write_tag(TAG_CELL_TIMESTAMP)
-            #timestamp in 64bit system should be different from 32bit system
+            #timestamp in 64bit system should be different from 32bit system TODO column could not add timestamp in the cell,it might be the 64 bit system of long type size
             self.output_stream.write_raw_little_endian64(timestamp)
             cell_check_sum = PlainBufferCrc8.crc_int64(cell_check_sum, timestamp)
         self.write_tag(TAG_CELL_CHECKSUM)

--- a/tablestore/plainbuffer/plain_buffer_coded_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_coded_stream.py
@@ -5,9 +5,9 @@ import struct
 from tablestore.const import *
 from tablestore.metadata import *
 from tablestore.error import *
-from plain_buffer_consts import *
-from plain_buffer_crc8 import *
-from plain_buffer_consts import *
+from .plain_buffer_consts import *
+from .plain_buffer_crc8 import *
+from .plain_buffer_consts import *
 
 class PlainBufferCodedInputStream(object):
     def __init__(self, input_stream):
@@ -254,13 +254,13 @@ class PlainBufferCodedOutputStream(object):
             self.output_stream.write_raw_little_endian32(1)
             self.output_stream.write_raw_byte(VT_AUTO_INCREMENT)
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_AUTO_INCREMENT)
-        elif isinstance(value, int) or isinstance(value, long):
+        elif isinstance(value, int) or isinstance(value, int):
             self.output_stream.write_raw_little_endian32(1 + const.LITTLE_ENDIAN_64_SIZE)
             self.output_stream.write_raw_byte(VT_INTEGER)
             self.output_stream.write_raw_little_endian64(value)
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_INTEGER)
             cell_check_sum = PlainBufferCrc8.crc_int64(cell_check_sum, value)
-        elif isinstance(value, str) or isinstance(value, unicode):
+        elif isinstance(value, str) or isinstance(value, str):
             string_value = value
             prefix_length = const.LITTLE_ENDIAN_32_SIZE + 1
             self.output_stream.write_raw_little_endian32(prefix_length + len(string_value))
@@ -297,13 +297,13 @@ class PlainBufferCodedOutputStream(object):
                 cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, 1)
             else:
                 cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, 0)
-        elif isinstance(value, int) or isinstance(value, long):
+        elif isinstance(value, int) or isinstance(value, int):
             self.output_stream.write_raw_little_endian32(1 + LITTLE_ENDIAN_64_SIZE)
             self.output_stream.write_raw_byte(VT_INTEGER)
             self.output_stream.write_raw_little_endian64(value)
             cell_check_sum = PlainBufferCrc8.crc_int8(cell_check_sum, VT_INTEGER)
             cell_check_sum = PlainBufferCrc8.crc_int64(cell_check_sum, value)
-        elif isinstance(value, str) or isinstance(value, unicode):
+        elif isinstance(value, str) or isinstance(value, str):
             prefix_length = LITTLE_ENDIAN_32_SIZE + 1 
             self.output_stream.write_raw_little_endian32(prefix_length + len(value)) 
             self.output_stream.write_raw_byte(VT_STRING)
@@ -336,10 +336,10 @@ class PlainBufferCodedOutputStream(object):
         if isinstance(value, bool):
             self.output_stream.write_raw_byte(VT_BOOLEAN)
             self.output_stream.write_boolean(value)
-        elif isinstance(value, int) or isinstance(value, long):
+        elif isinstance(value, int) or isinstance(value, int):
             self.output_stream.write_raw_byte(VT_INTEGER)
             self.output_stream.write_raw_little_endian64(value)
-        elif isinstance(value, str) or isinstance(value, unicode):
+        elif isinstance(value, str) or isinstance(value, str):
             self.output_stream.write_raw_byte(VT_STRING)
             self.output_stream.write_raw_little_endian32(len(value))
             self.output_stream.write_bytes(value)
@@ -434,10 +434,10 @@ class PlainBufferCodedOutputStream(object):
     def write_update_columns(self, attribute_columns, row_check_sum):
         if len(attribute_columns) != 0:
             self.write_tag(TAG_ROW_DATA)
-            for update_type in attribute_columns.keys():
+            for update_type in list(attribute_columns.keys()):
                 columns = attribute_columns[update_type]
                 for column in columns:
-                    if isinstance(column, str) or isinstance(column, unicode):
+                    if isinstance(column, str) or isinstance(column, str):
                         row_check_sum = self.write_update_column(update_type, column, None, row_check_sum)
                     elif len(column) == 2:
                         row_check_sum = self.write_update_column(update_type, column[0], (column[1], None), row_check_sum)

--- a/tablestore/plainbuffer/plain_buffer_consts.py
+++ b/tablestore/plainbuffer/plain_buffer_consts.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import tablestore.const as const
 

--- a/tablestore/plainbuffer/plain_buffer_consts.py
+++ b/tablestore/plainbuffer/plain_buffer_consts.py
@@ -36,3 +36,13 @@ const.LITTLE_ENDIAN_32_SIZE = 4
 const.LITTLE_ENDIAN_64_SIZE = 8
 const.MAX_BUFFER_SIZE = 64 * 1024 * 1024
 
+import platform
+const.SYS_BITS=int(platform.architecture()[0][:2])
+if const.SYS_BITS == 64:
+    const.LITTLE_ENDIAN_SIZE = const.LITTLE_ENDIAN_64_SIZE
+elif const.SYS_BITS == 32:
+    const.LITTLE_ENDIAN_SIZE = const.LITTLE_ENDIAN_32_SIZE
+else:
+    const.LITTLE_ENDIAN_SIZE = 4
+
+

--- a/tablestore/plainbuffer/plain_buffer_crc8.py
+++ b/tablestore/plainbuffer/plain_buffer_crc8.py
@@ -3,7 +3,7 @@
 
 import sys
 import crcmod
-
+import struct
 CRC8_TABLE = [0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,
               0x38, 0x3f, 0x36, 0x31, 0x24, 0x23, 0x2a, 0x2d,
               0x70, 0x77, 0x7e, 0x79, 0x6c, 0x6b, 0x62, 0x65,
@@ -42,20 +42,19 @@ CRC8_TABLE = [0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,
 class PlainBufferCrc8(object):
     @staticmethod
     def update(crc, bytes_):
-        crc8Checker = crcmod.predefined.Crc('crc-8')
-        crc8Checker.crcValue = crc
-        return PlainBufferCrc8._update(crc, bytes_,crc8Checker)
+        return PlainBufferCrc8._update(crc, bytes_)
 
     @staticmethod
-    def _update(crc, bytes_,crcChecker):
+    def _update(crc, bytes_):
         if isinstance(bytes_, bytes):
             bytes_ = bytes_.decode('utf-8')
         elif not isinstance(bytes_, str):
             raise TypeError("must be string or buffer, actual:" + str(type(bytes_)))
-        for byte in bytes_:
-            # crc = CRC8_TABLE[((crc&0xff)^ord(byte))]
-            crcChecker.update(byte.encode('utf-8'))
-            crc = crcChecker.crcValue
+        crc8Checker = crcmod.predefined.Crc('crc-8')
+        crc = crc8Checker._crc(bytes_.encode('utf-8'),crc=crc)
+        # for byte in bytes_:
+        #     # crc = CRC8_TABLE[((crc&0xff)^ord(byte))]
+        #
         return crc
 
     @staticmethod
@@ -66,26 +65,21 @@ class PlainBufferCrc8(object):
     def crc_int8(crc, byte):
         # return CRC8_TABLE[((crc & 0xff)^byte)]
         crcChecker = crcmod.predefined.Crc('crc-8')
-        crcChecker.crcValue = crc
-        crcChecker.update(bytes([byte]))
-        crc = crcChecker.crcValue
+        crc = crcChecker._crc(bytes([byte]),crc=crc)
         return crc
 
     @staticmethod
     def crc_int32(crc, byte):
         for i in range(0, 4):
             crc = PlainBufferCrc8.crc_int8(crc, (byte>>(i*8)) & 0xff)
-        # crcChecker = crcmod.predefined.Crc('crc-8')
-        # crcChecker.crcValue = crc
-        # crcChecker.update([byte])
-        # crc = crcChecker.crcValue
         return crc
 
     @staticmethod
     def crc_int64(crc, byte):
-        for i in range(0, 8):
-            crc = PlainBufferCrc8.crc_int8(crc, (byte>>(i*8)) & 0xff)
-
+        # for i in range(0, 8):
+        #     crc = PlainBufferCrc8.crc_int8(crc, (byte>>(i*8)) & 0xff)
+        crcChecker = crcmod.predefined.Crc('crc-8')
+        crc=crcChecker._crc(struct.pack('q', byte), crc=crc)
         return crc
 
 

--- a/tablestore/plainbuffer/plain_buffer_crc8.py
+++ b/tablestore/plainbuffer/plain_buffer_crc8.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import sys
 

--- a/tablestore/plainbuffer/plain_buffer_crc8.py
+++ b/tablestore/plainbuffer/plain_buffer_crc8.py
@@ -64,18 +64,28 @@ class PlainBufferCrc8(object):
 
     @staticmethod
     def crc_int8(crc, byte):
-        return CRC8_TABLE[((crc & 0xff)^byte)]
+        # return CRC8_TABLE[((crc & 0xff)^byte)]
+        crcChecker = crcmod.predefined.Crc('crc-8')
+        crcChecker.crcValue = crc
+        crcChecker.update(bytes([byte]))
+        crc = crcChecker.crcValue
+        return crc
 
     @staticmethod
     def crc_int32(crc, byte):
         for i in range(0, 4):
             crc = PlainBufferCrc8.crc_int8(crc, (byte>>(i*8)) & 0xff)
+        # crcChecker = crcmod.predefined.Crc('crc-8')
+        # crcChecker.crcValue = crc
+        # crcChecker.update([byte])
+        # crc = crcChecker.crcValue
         return crc
 
     @staticmethod
     def crc_int64(crc, byte):
         for i in range(0, 8):
             crc = PlainBufferCrc8.crc_int8(crc, (byte>>(i*8)) & 0xff)
+
         return crc
 
 

--- a/tablestore/plainbuffer/plain_buffer_crc8.py
+++ b/tablestore/plainbuffer/plain_buffer_crc8.py
@@ -42,7 +42,7 @@ class PlainBufferCrc8(object):
 
     @staticmethod
     def _update(crc, bytes_):
-        if isinstance(bytes_, unicode):
+        if isinstance(bytes_, str):
             bytes_ = bytes_.encode()
         elif not isinstance(bytes_, str):
             raise TypeError("must be string or buffer, actual:" + str(type(bytes_)))

--- a/tablestore/plainbuffer/plain_buffer_crc8.py
+++ b/tablestore/plainbuffer/plain_buffer_crc8.py
@@ -42,8 +42,8 @@ class PlainBufferCrc8(object):
 
     @staticmethod
     def _update(crc, bytes_):
-        if isinstance(bytes_, str):
-            bytes_ = bytes_.encode()
+        if isinstance(bytes_, bytes):
+            bytes_ = bytes_.decode()
         elif not isinstance(bytes_, str):
             raise TypeError("must be string or buffer, actual:" + str(type(bytes_)))
         for byte in bytes_:            

--- a/tablestore/plainbuffer/plain_buffer_crc8.py
+++ b/tablestore/plainbuffer/plain_buffer_crc8.py
@@ -2,6 +2,7 @@
 #  @Author  : LiXiaoran
 
 import sys
+import crcmod
 
 CRC8_TABLE = [0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,
               0x38, 0x3f, 0x36, 0x31, 0x24, 0x23, 0x2a, 0x2d,
@@ -36,19 +37,25 @@ CRC8_TABLE = [0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,
               0xde, 0xd9, 0xd0, 0xd7, 0xc2, 0xc5, 0xcc, 0xcb,
               0xe6, 0xe1, 0xe8, 0xef, 0xfa, 0xfd, 0xf4, 0xf3]
 
+
+
 class PlainBufferCrc8(object):
     @staticmethod
     def update(crc, bytes_):
-        return PlainBufferCrc8._update(crc, bytes_)
+        crc8Checker = crcmod.predefined.Crc('crc-8')
+        crc8Checker.crcValue = crc
+        return PlainBufferCrc8._update(crc, bytes_,crc8Checker)
 
     @staticmethod
-    def _update(crc, bytes_):
+    def _update(crc, bytes_,crcChecker):
         if isinstance(bytes_, bytes):
-            bytes_ = bytes_.decode()
+            bytes_ = bytes_.decode('utf-8')
         elif not isinstance(bytes_, str):
             raise TypeError("must be string or buffer, actual:" + str(type(bytes_)))
-        for byte in bytes_:            
-            crc = CRC8_TABLE[((crc&0xff)^ord(byte))]
+        for byte in bytes_:
+            # crc = CRC8_TABLE[((crc&0xff)^ord(byte))]
+            crcChecker.update(byte.encode('utf-8'))
+            crc = crcChecker.crcValue
         return crc
 
     @staticmethod

--- a/tablestore/plainbuffer/plain_buffer_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_stream.py
@@ -18,13 +18,13 @@ class PlainBufferInputStream(object):
             return 0
 
         self.last_tag = self.read_raw_byte()
-        return ord(self.last_tag)
+        return ord(self.last_tag.decode())
 
     def check_last_tag_was(self, tag):
-        return ord(self.last_tag) == tag
+        return ord(self.last_tag.decode()) == tag
 
     def get_last_tag(self):
-        return ord(self.last_tag)
+        return ord(self.last_tag.decode())
 
     def read_raw_byte(self):
         if self.is_at_end():
@@ -32,7 +32,7 @@ class PlainBufferInputStream(object):
 
         pos = self.cur_pos
         self.cur_pos += 1
-        return bytes(self.buffer[pos])
+        return chr(self.buffer[pos]).encode()
 
     def read_raw_little_endian64(self):
         return struct.unpack('<q', self.read_bytes(8))[0]
@@ -108,5 +108,8 @@ class PlainBufferOutputStream(object):
     def write_bytes(self, value):
         if len(self.buffer) + len(value) > self.capacity:
             raise OTSClientError("The buffer is full.")
-        # self.buffer += bytearray(value)
+        if isinstance(value,str):
+            value = value.encode()
+        self.buffer += bytearray(value)
+        # self.buffer.append(value)
         # self.buffer += value

--- a/tablestore/plainbuffer/plain_buffer_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_stream.py
@@ -19,13 +19,13 @@ class PlainBufferInputStream(object):
             return 0
 
         self.last_tag = self.read_raw_byte()
-        return ord(self.last_tag.decode())
+        return ord(self.last_tag.decode('utf-8'))
 
     def check_last_tag_was(self, tag):
-        return ord(self.last_tag.decode()) == tag
+        return ord(self.last_tag.decode('utf-8')) == tag
 
     def get_last_tag(self):
-        return ord(self.last_tag.decode())
+        return ord(self.last_tag.decode('utf-8'))
 
     def read_raw_byte(self):
         if self.is_at_end():
@@ -33,7 +33,7 @@ class PlainBufferInputStream(object):
 
         pos = self.cur_pos
         self.cur_pos += 1
-        return chr(self.buffer[pos]).encode()
+        return chr(self.buffer[pos]).encode('utf-8')
 
     def read_raw_little_endian64(self):
         return struct.unpack('<q', self.read_bytes(8))[0]
@@ -110,7 +110,7 @@ class PlainBufferOutputStream(object):
         if len(self.buffer) + len(value) > self.capacity:
             raise OTSClientError("The buffer is full.")
         if isinstance(value,str):
-            value = value.encode()
+            value = value.encode('utf-8')
         self.buffer += bytearray(value)
         # self.buffer.append(value)
         # self.buffer += value

--- a/tablestore/plainbuffer/plain_buffer_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_stream.py
@@ -108,4 +108,5 @@ class PlainBufferOutputStream(object):
     def write_bytes(self, value):
         if len(self.buffer) + len(value) > self.capacity:
             raise OTSClientError("The buffer is full.")
-        self.buffer += bytearray(value)
+        # self.buffer += bytearray(value)
+        # self.buffer += value

--- a/tablestore/plainbuffer/plain_buffer_stream.py
+++ b/tablestore/plainbuffer/plain_buffer_stream.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import struct
 from tablestore.error import *

--- a/tablestore/protobuf/decoder.py
+++ b/tablestore/protobuf/decoder.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import google.protobuf.text_format as text_format
 

--- a/tablestore/protobuf/encoder.py
+++ b/tablestore/protobuf/encoder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf8 -*-# @Author  : LiXiaoran
 
 import google.protobuf.text_format as text_format
 
@@ -431,7 +431,7 @@ class OTSProtoBufferEncoder(object):
                 table_item.filter = pb_filter.SerializeToString()
 
             for pk in item.primary_keys:
-                table_item.primary_key.append(str(PlainBufferBuilder.serialize_primary_key(pk)))
+                table_item.primary_key.append(bytes(PlainBufferBuilder.serialize_primary_key(pk)))
             if item.token is not None:
                 for token in item.token:
                     table_item.token.append(token)
@@ -464,7 +464,7 @@ class OTSProtoBufferEncoder(object):
         if put_row_item.return_type == ReturnType.RT_PK:
             proto.return_content.return_type = pb2.RT_PK
 
-        proto.row_change = str(PlainBufferBuilder.serialize_for_put_row(
+        proto.row_change = bytes(PlainBufferBuilder.serialize_for_put_row(
                 put_row_item.row.primary_key, put_row_item.row.attribute_columns))
         proto.type = pb2.PUT
         return proto
@@ -478,7 +478,7 @@ class OTSProtoBufferEncoder(object):
         if update_row_item.return_type == ReturnType.RT_PK:
             proto.return_content.return_type = pb2.RT_PK
 
-        proto.row_change = str(PlainBufferBuilder.serialize_for_update_row(
+        proto.row_change = bytes(PlainBufferBuilder.serialize_for_update_row(
                 update_row_item.row.primary_key, update_row_item.row.attribute_columns))
         proto.type = pb2.UPDATE
         return proto
@@ -492,7 +492,7 @@ class OTSProtoBufferEncoder(object):
         if delete_row_item.return_type == ReturnType.RT_PK:
             proto.return_content.return_type = pb2.RT_PK
 
-        proto.row_change = str(PlainBufferBuilder.serialize_for_delete_row(delete_row_item.row.primary_key))
+        proto.row_change = bytes(PlainBufferBuilder.serialize_for_delete_row(delete_row_item.row.primary_key))
         proto.type = pb2.DELETE
         return proto
 

--- a/tablestore/protobuf/encoder.py
+++ b/tablestore/protobuf/encoder.py
@@ -73,9 +73,9 @@ class OTSProtoBufferEncoder(object):
         }
 
     def _get_unicode(self, value):
-        if isinstance(value, str):
+        if isinstance(value, bytes):
             return value.decode(self.encoding)
-        elif isinstance(value, unicode):
+        elif isinstance(value, str):
             return value
         else:
             raise OTSClientError(
@@ -84,7 +84,7 @@ class OTSProtoBufferEncoder(object):
             )
 
     def _get_int32(self, int32):
-        if isinstance(int32, int) or isinstance(int32, long):
+        if isinstance(int32, int) or isinstance(int32, int):
             if int32 < INT32_MIN or int32 > INT32_MAX:
                 raise OTSClientError("%s exceeds the range of int32" % int32)
             return int32
@@ -112,14 +112,14 @@ class OTSProtoBufferEncoder(object):
         # you have to put 'int' under 'bool' in the switch case
         # because a bool is also a int !!!
 
-        if isinstance(value, str) or isinstance(value, unicode):
+        if isinstance(value, str) or isinstance(value, str):
             string = self._get_unicode(value)
             proto.type = pb2.STRING
             proto.v_string = string
         elif isinstance(value, bool):
             proto.type = pb2.BOOLEAN
             proto.v_bool = value
-        elif isinstance(value, int) or isinstance(value, long):
+        elif isinstance(value, int) or isinstance(value, int):
             proto.type = pb2.INTEGER
             proto.v_int = value
         elif isinstance(value, float):
@@ -149,7 +149,7 @@ class OTSProtoBufferEncoder(object):
         else:
             raise OTSClientError(
                 "primary_key_option should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(option)
+                    ", ".join(list(enum_map.keys())), str(option)
                 )
             )
 
@@ -164,7 +164,7 @@ class OTSProtoBufferEncoder(object):
         else:
             raise OTSClientError(
                 "primary_key_type should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(type_str)
+                    ", ".join(list(enum_map.keys())), str(type_str)
                 )
             )
 
@@ -179,7 +179,7 @@ class OTSProtoBufferEncoder(object):
         if proto.combinator is None:
             raise OTSClientError(
                 "LogicalOperator should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(condition.combinator)
+                    ", ".join(list(enum_map.keys())), str(condition.combinator)
                 )
             )
 
@@ -199,7 +199,7 @@ class OTSProtoBufferEncoder(object):
         if proto.comparator is None: 
             raise OTSClientError(
                 "ComparatorType should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(condition.comparator)
+                    ", ".join(list(enum_map.keys())), str(condition.comparator)
                 )
             )
 
@@ -229,7 +229,7 @@ class OTSProtoBufferEncoder(object):
         if proto.type is None:
             raise OTSClientError(
                 "column_condition_type should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(column_condition.type)
+                    ", ".join(list(enum_map.keys())), str(column_condition.type)
                 )
             )
 
@@ -261,7 +261,7 @@ class OTSProtoBufferEncoder(object):
         if proto.row_existence is None:
             raise OTSClientError(
                 "row_existence_expectation should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(expectation_str)
+                    ", ".join(list(enum_map.keys())), str(expectation_str)
                 )
             )
 
@@ -280,7 +280,7 @@ class OTSProtoBufferEncoder(object):
         else:
             raise OTSClientError(
                 "direction should be one of [%s], not %s" % (
-                    ", ".join(enum_map.keys()), str(direction_str)
+                    ", ".join(list(enum_map.keys())), str(direction_str)
                 )
             )
 
@@ -302,7 +302,7 @@ class OTSProtoBufferEncoder(object):
             self._make_column_schema(schema_proto, schema_tuple)
 
     def _make_columns_with_dict(self, proto, column_dict):
-        for name, value in column_dict.iteritems():
+        for name, value in column_dict.items():
             item = proto.add()
             item.name = self._get_unicode(name)
             self._make_column_value(item.value, value)
@@ -316,7 +316,7 @@ class OTSProtoBufferEncoder(object):
                 )
             )
 
-        for key, value in column_dict.iteritems():
+        for key, value in column_dict.items():
             if key == 'put':
                 if not isinstance(column_dict[key], dict):
                     raise OTSClientError(
@@ -324,7 +324,7 @@ class OTSProtoBufferEncoder(object):
                             column_dict[key].__class__.__name__
                         )
                     )
-                for name, value in column_dict[key].iteritems():
+                for name, value in column_dict[key].items():
                     item = proto.add()
                     item.type = pb2.PUT
                     item.name = self._get_unicode(name)
@@ -420,7 +420,7 @@ class OTSProtoBufferEncoder(object):
         self._make_update_capacity_unit(proto.capacity_unit, reserved_throughput.capacity_unit)
 
     def _make_batch_get_row_internal(self, proto, request):
-        for table_name, item in request.items.items():
+        for table_name, item in list(request.items.items()):
             table_item = proto.tables.add()
             table_item.table_name = self._get_unicode(item.table_name)
             self._make_repeated_column_names(table_item.columns_to_get, item.columns_to_get)
@@ -442,7 +442,7 @@ class OTSProtoBufferEncoder(object):
                 if isinstance(item.time_range, tuple):
                     table_item.time_range.start_time = item.time_range[0]
                     table_item.time_range.end_time = item.time_range[1]
-                elif isinstance(item.time_range, int) or isinstance(item.time_range, long):
+                elif isinstance(item.time_range, int) or isinstance(item.time_range, int):
                     table_item.time_range.specific_time = item.time_range
 
             if item.start_column is not None:
@@ -497,7 +497,7 @@ class OTSProtoBufferEncoder(object):
         return proto
 
     def _make_batch_write_row_internal(self, proto, request):
-        for table_name, item in request.items.items():
+        for table_name, item in list(request.items.items()):
             table_item = proto.tables.add()
             table_item.table_name = self._get_unicode(item.table_name)
 
@@ -568,7 +568,7 @@ class OTSProtoBufferEncoder(object):
             if isinstance(time_range, tuple):
                 proto.time_range.start_time = time_range[0]
                 proto.time_range.end_time = time_range[1]
-            elif isinstance(time_range, int) or isinstance(time_range, long):
+            elif isinstance(time_range, int) or isinstance(time_range, int):
                 proto.time_range.specific_time = time_range
 
         if start_column is not None:
@@ -654,7 +654,7 @@ class OTSProtoBufferEncoder(object):
             if isinstance(time_range, tuple):
                 proto.time_range.start_time = time_range[0]
                 proto.time_range.end_time = time_range[1]
-            elif isinstance(time_range, int) or isinstance(time_range, long):
+            elif isinstance(time_range, int) or isinstance(time_range, int):
                 proto.time_range.specific_time = time_range 
         if start_column is not None:
             proto.start_column = start_column

--- a/tablestore/protobuf/encoder.py
+++ b/tablestore/protobuf/encoder.py
@@ -602,7 +602,7 @@ class OTSProtoBufferEncoder(object):
         if return_type == ReturnType.RT_PK:
             proto.return_content.return_type = pb2.RT_PK
 
-        proto.row_change = str(PlainBufferBuilder.serialize_for_update_row(row.primary_key, row.attribute_columns))
+        proto.row_change = bytes(PlainBufferBuilder.serialize_for_update_row(row.primary_key, row.attribute_columns))
         return proto
 
     def _encode_delete_row(self, table_name, row, condition, return_type):
@@ -615,7 +615,7 @@ class OTSProtoBufferEncoder(object):
         if return_type == ReturnType.RT_PK:
             proto.return_content.return_type = pb2.RT_PK
 
-        proto.primary_key = str(PlainBufferBuilder.serialize_for_delete_row(row.primary_key))
+        proto.primary_key = bytes(PlainBufferBuilder.serialize_for_delete_row(row.primary_key))
         return proto
 
     def _encode_batch_get_row(self, request):
@@ -638,8 +638,8 @@ class OTSProtoBufferEncoder(object):
         proto.direction = self._get_direction(direction)
         self._make_repeated_column_names(proto.columns_to_get, columns_to_get)
 
-        proto.inclusive_start_primary_key = str(PlainBufferBuilder.serialize_primary_key(inclusive_start_primary_key))
-        proto.exclusive_end_primary_key = str(PlainBufferBuilder.serialize_primary_key(exclusive_end_primary_key))
+        proto.inclusive_start_primary_key = bytes(PlainBufferBuilder.serialize_primary_key(inclusive_start_primary_key))
+        proto.exclusive_end_primary_key = bytes(PlainBufferBuilder.serialize_primary_key(exclusive_end_primary_key))
 
         if column_filter is not None:
             pb_filter = filter_pb2.Filter()

--- a/tablestore/protobuf/encoder.py
+++ b/tablestore/protobuf/encoder.py
@@ -205,7 +205,7 @@ class OTSProtoBufferEncoder(object):
 
         proto.column_name = self._get_unicode(condition.column_name)
         #self._make_column_value(proto.column_value, condition.column_value)
-        proto.column_value = str(PlainBufferBuilder.serialize_column_value(condition.column_value))
+        proto.column_value = bytes(PlainBufferBuilder.serialize_column_value(condition.column_value))
         proto.filter_if_missing = not condition.pass_if_missing 
         proto.latest_version_only = condition.latest_version_only
 
@@ -561,7 +561,7 @@ class OTSProtoBufferEncoder(object):
             self._make_column_condition(pb_filter, column_filter)
             proto.filter = pb_filter.SerializeToString()
 
-        proto.primary_key = str(PlainBufferBuilder.serialize_primary_key(primary_key))
+        proto.primary_key = bytes(PlainBufferBuilder.serialize_primary_key(primary_key))
         if max_version is not None:
             proto.max_versions = max_version
         if time_range is not None:
@@ -589,7 +589,7 @@ class OTSProtoBufferEncoder(object):
         if return_type == ReturnType.RT_PK:
             proto.return_content.return_type = pb2.RT_PK
 
-        proto.row = str(PlainBufferBuilder.serialize_for_put_row(row.primary_key, row.attribute_columns))
+        proto.row = bytes(PlainBufferBuilder.serialize_for_put_row(row.primary_key, row.attribute_columns))
         return proto
 
     def _encode_update_row(self, table_name, row, condition, return_type):

--- a/tablestore/protobuf/table_store_filter_pb2.py
+++ b/tablestore/protobuf/table_store_filter_pb2.py
@@ -138,7 +138,7 @@ _SINGLECOLUMNVALUEFILTER = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='column_name', full_name='com.aliyun.tablestore.protocol.SingleColumnValueFilter.column_name', index=1,
       number=2, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -290,26 +290,22 @@ DESCRIPTOR.message_types_by_name['CompositeColumnValueFilter'] = _COMPOSITECOLUM
 DESCRIPTOR.message_types_by_name['ColumnPaginationFilter'] = _COLUMNPAGINATIONFILTER
 DESCRIPTOR.message_types_by_name['Filter'] = _FILTER
 
-class SingleColumnValueFilter(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
+class SingleColumnValueFilter(_message.Message, metaclass=_reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _SINGLECOLUMNVALUEFILTER
 
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.SingleColumnValueFilter)
 
-class CompositeColumnValueFilter(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
+class CompositeColumnValueFilter(_message.Message, metaclass=_reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _COMPOSITECOLUMNVALUEFILTER
 
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.CompositeColumnValueFilter)
 
-class ColumnPaginationFilter(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
+class ColumnPaginationFilter(_message.Message, metaclass=_reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _COLUMNPAGINATIONFILTER
 
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ColumnPaginationFilter)
 
-class Filter(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
+class Filter(_message.Message, metaclass=_reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _FILTER
 
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.Filter)

--- a/tablestore/protobuf/table_store_pb2.py
+++ b/tablestore/protobuf/table_store_pb2.py
@@ -180,14 +180,14 @@ _ERROR = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='code', full_name='com.aliyun.tablestore.protocol.Error.code', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     descriptor.FieldDescriptor(
       name='message', full_name='com.aliyun.tablestore.protocol.Error.message', index=1,
       number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -215,7 +215,7 @@ _PRIMARYKEYSCHEMA = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='name', full_name='com.aliyun.tablestore.protocol.PrimaryKeySchema.name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -334,7 +334,7 @@ _TABLEMETA = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.TableMeta.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -607,7 +607,7 @@ _UPDATETABLEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.UpdateTableRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -684,7 +684,7 @@ _DESCRIBETABLEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.DescribeTableRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -810,7 +810,7 @@ _DELETETABLEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.DeleteTableRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -859,7 +859,7 @@ _LOADTABLEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.LoadTableRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -908,7 +908,7 @@ _UNLOADTABLEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.UnloadTableRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1027,7 +1027,7 @@ _GETROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.GetRowRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1069,14 +1069,14 @@ _GETROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='start_column', full_name='com.aliyun.tablestore.protocol.GetRowRequest.start_column', index=6,
       number=8, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     descriptor.FieldDescriptor(
       name='end_column', full_name='com.aliyun.tablestore.protocol.GetRowRequest.end_column', index=7,
       number=9, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1153,7 +1153,7 @@ _UPDATEROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.UpdateRowRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1237,7 +1237,7 @@ _PUTROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.PutRowRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1321,7 +1321,7 @@ _DELETEROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.DeleteRowRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1405,7 +1405,7 @@ _TABLEINBATCHGETROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.TableInBatchGetRowRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1454,14 +1454,14 @@ _TABLEINBATCHGETROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='start_column', full_name='com.aliyun.tablestore.protocol.TableInBatchGetRowRequest.start_column', index=7,
       number=9, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     descriptor.FieldDescriptor(
       name='end_column', full_name='com.aliyun.tablestore.protocol.TableInBatchGetRowRequest.end_column', index=8,
       number=10, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1573,7 +1573,7 @@ _TABLEINBATCHGETROWRESPONSE = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.TableInBatchGetRowResponse.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1685,7 +1685,7 @@ _TABLEINBATCHWRITEROWREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.TableInBatchWriteRowRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1797,7 +1797,7 @@ _TABLEINBATCHWRITEROWRESPONSE = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.TableInBatchWriteRowResponse.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1860,7 +1860,7 @@ _GETRANGEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='table_name', full_name='com.aliyun.tablestore.protocol.GetRangeRequest.table_name', index=0,
       number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -1923,14 +1923,14 @@ _GETRANGEREQUEST = descriptor.Descriptor(
     descriptor.FieldDescriptor(
       name='start_column', full_name='com.aliyun.tablestore.protocol.GetRangeRequest.start_column', index=9,
       number=11, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     descriptor.FieldDescriptor(
       name='end_column', full_name='com.aliyun.tablestore.protocol.GetRangeRequest.end_column', index=10,
       number=12, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=unicode("", "utf-8"),
+      has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -2099,284 +2099,237 @@ DESCRIPTOR.message_types_by_name['BatchWriteRowResponse'] = _BATCHWRITEROWRESPON
 DESCRIPTOR.message_types_by_name['GetRangeRequest'] = _GETRANGEREQUEST
 DESCRIPTOR.message_types_by_name['GetRangeResponse'] = _GETRANGERESPONSE
 
-class Error(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class Error(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _ERROR
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.Error)
 
-class PrimaryKeySchema(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class PrimaryKeySchema(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _PRIMARYKEYSCHEMA
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.PrimaryKeySchema)
 
-class PartitionRange(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class PartitionRange(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _PARTITIONRANGE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.PartitionRange)
 
-class TableOptions(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TableOptions(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TABLEOPTIONS
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TableOptions)
 
-class TableMeta(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TableMeta(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TABLEMETA
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TableMeta)
 
-class Condition(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class Condition(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _CONDITION
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.Condition)
 
-class CapacityUnit(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class CapacityUnit(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _CAPACITYUNIT
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.CapacityUnit)
 
-class ReservedThroughputDetails(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class ReservedThroughputDetails(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _RESERVEDTHROUGHPUTDETAILS
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ReservedThroughputDetails)
 
-class ReservedThroughput(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class ReservedThroughput(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _RESERVEDTHROUGHPUT
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ReservedThroughput)
 
-class ConsumedCapacity(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class ConsumedCapacity(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _CONSUMEDCAPACITY
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ConsumedCapacity)
 
-class CreateTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class CreateTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _CREATETABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.CreateTableRequest)
 
-class CreateTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class CreateTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _CREATETABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.CreateTableResponse)
 
-class UpdateTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class UpdateTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _UPDATETABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.UpdateTableRequest)
 
-class UpdateTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class UpdateTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _UPDATETABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.UpdateTableResponse)
 
-class DescribeTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class DescribeTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _DESCRIBETABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.DescribeTableRequest)
 
-class DescribeTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class DescribeTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _DESCRIBETABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.DescribeTableResponse)
 
-class ListTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class ListTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _LISTTABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ListTableRequest)
 
-class ListTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class ListTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _LISTTABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ListTableResponse)
 
-class DeleteTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class DeleteTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _DELETETABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.DeleteTableRequest)
 
-class DeleteTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class DeleteTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _DELETETABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.DeleteTableResponse)
 
-class LoadTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class LoadTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _LOADTABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.LoadTableRequest)
 
-class LoadTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class LoadTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _LOADTABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.LoadTableResponse)
 
-class UnloadTableRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class UnloadTableRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _UNLOADTABLEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.UnloadTableRequest)
 
-class UnloadTableResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class UnloadTableResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _UNLOADTABLERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.UnloadTableResponse)
 
-class TimeRange(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TimeRange(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TIMERANGE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TimeRange)
 
-class ReturnContent(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class ReturnContent(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _RETURNCONTENT
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.ReturnContent)
 
-class GetRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class GetRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _GETROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.GetRowRequest)
 
-class GetRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class GetRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _GETROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.GetRowResponse)
 
-class UpdateRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class UpdateRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _UPDATEROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.UpdateRowRequest)
 
-class UpdateRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class UpdateRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _UPDATEROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.UpdateRowResponse)
 
-class PutRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class PutRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _PUTROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.PutRowRequest)
 
-class PutRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class PutRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _PUTROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.PutRowResponse)
 
-class DeleteRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class DeleteRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _DELETEROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.DeleteRowRequest)
 
-class DeleteRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class DeleteRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _DELETEROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.DeleteRowResponse)
 
-class TableInBatchGetRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TableInBatchGetRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TABLEINBATCHGETROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TableInBatchGetRowRequest)
 
-class BatchGetRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class BatchGetRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _BATCHGETROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.BatchGetRowRequest)
 
-class RowInBatchGetRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class RowInBatchGetRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _ROWINBATCHGETROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.RowInBatchGetRowResponse)
 
-class TableInBatchGetRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TableInBatchGetRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TABLEINBATCHGETROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TableInBatchGetRowResponse)
 
-class BatchGetRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class BatchGetRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _BATCHGETROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.BatchGetRowResponse)
 
-class RowInBatchWriteRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class RowInBatchWriteRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _ROWINBATCHWRITEROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.RowInBatchWriteRowRequest)
 
-class TableInBatchWriteRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TableInBatchWriteRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TABLEINBATCHWRITEROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TableInBatchWriteRowRequest)
 
-class BatchWriteRowRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class BatchWriteRowRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _BATCHWRITEROWREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.BatchWriteRowRequest)
 
-class RowInBatchWriteRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class RowInBatchWriteRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _ROWINBATCHWRITEROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.RowInBatchWriteRowResponse)
 
-class TableInBatchWriteRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class TableInBatchWriteRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _TABLEINBATCHWRITEROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.TableInBatchWriteRowResponse)
 
-class BatchWriteRowResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class BatchWriteRowResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _BATCHWRITEROWRESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.BatchWriteRowResponse)
 
-class GetRangeRequest(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class GetRangeRequest(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _GETRANGEREQUEST
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.GetRangeRequest)
 
-class GetRangeResponse(message.Message):
-  __metaclass__ = reflection.GeneratedProtocolMessageType
+class GetRangeResponse(message.Message, metaclass=reflection.GeneratedProtocolMessageType):
   DESCRIPTOR = _GETRANGERESPONSE
   
   # @@protoc_insertion_point(class_scope:com.aliyun.tablestore.protocol.GetRangeResponse)

--- a/tablestore/protocol.py
+++ b/tablestore/protocol.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 
 import hashlib
 import urllib.request, urllib.parse, urllib.error

--- a/tablestore/protocol.py
+++ b/tablestore/protocol.py
@@ -68,7 +68,7 @@ class OTSProtocol(object):
         # The signature method is supposed to be HmacSHA1
         # A switch case is required if there is other methods available
         signature = base64.b64encode(hmac.new(
-            self.user_key.encode(), signature_string.encode(), hashlib.sha1
+            self.user_key.encode('utf-8'), signature_string.encode('utf-8'), hashlib.sha1
         ).digest())
         return signature
 

--- a/tablestore/retry.py
+++ b/tablestore/retry.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+#  @Author  : LiXiaoran
 import random
 import math
 


### PR DESCRIPTION
全部接口已测试完毕,在python3.4+以后版本都可以完成，表所有操作，单行所有操作，批量操作api都已测试完毕。
目前还需要做一下事情：
1，测试用例没有写
2，还有一个小bug 目前没找到原因： 在put_row过程当中，每一个column不能加timestamp的版本号，初步探查是因为在64位系统当中，转换为protobuff的过程当中 ，将int 转化为 c语言的long的时候，长度问题造成的。如果不加timestamp 所有接口已经测试完成
3， 由于是直接修改代码，因此代码当中没有加 python2 或python3的版本判断。 请merge时候注意