### PR TITLE
fix: Change the spelling of "end_colun" to "end_column".

### DIFF
--- a/tablestore/encoder.py
+++ b/tablestore/encoder.py
@@ -858,7 +858,7 @@ class OTSProtoBufferEncoder(object):
         if start_column is not None:
             proto.start_column = start_column
         if end_column is not None:
-            proto.end_colun = end_column
+            proto.end_column = end_column
         if token is not None:
             proto.token = token
         if transaction_id is not None:


### PR DESCRIPTION
修复参数拼写错误，end_colun 改成 end_column。